### PR TITLE
Workaround error from az function

### DIFF
--- a/src/code/Deployment/AzData/Get-Deployment.ps1
+++ b/src/code/Deployment/AzData/Get-Deployment.ps1
@@ -19,7 +19,7 @@ function Get-Deployment {
         )]
         [string]$Scope = "Current"
     )
-    
+
     begin {}
     process {
         switch ($context) {
@@ -29,7 +29,7 @@ function Get-Deployment {
                     return $Deployment
                 }
 
-                $Deployments = Get-AzResourceGroupDeployment -ResourceGroupName $Deployment.ResourceGroupName | Where-Object { $_.CorrelationId -eq $Deployment.CorrelationId }
+                $Deployments = Get-AzResourceGroupDeployment -ResourceGroupName $Deployment.ResourceGroupName -ErrorAction SilentlyContinue | Where-Object { $_.CorrelationId -eq $Deployment.CorrelationId }
                 if ($Scope -eq "Children") {
                     $Deployments = $Deployments | Where-Object { $_.Id -ne $id }
                 }


### PR DESCRIPTION
In newer versions Get-AzResourceGroupDeployment it will output 'Object reference not set to an instance of an object.' when trying to get deployments from a RG.

ErrorAction SilentlyContinue is a workaround to not get false error running deployment